### PR TITLE
Allow for spaces within direct channel author names.

### DIFF
--- a/src/main/java/jenkins/plugins/mattermost/StandardMattermostService.java
+++ b/src/main/java/jenkins/plugins/mattermost/StandardMattermostService.java
@@ -29,7 +29,7 @@ public class StandardMattermostService implements MattermostService {
 	public StandardMattermostService(String endpoint, String roomId, String icon) {
 		super();
 		this.endpoint = endpoint;
-		this.roomIds = roomId.split("[,; ]+");
+		this.roomIds = roomId.split("[,;]+");
 		this.icon = icon;
 	}
 
@@ -41,7 +41,7 @@ public class StandardMattermostService implements MattermostService {
 		boolean result = true;
 		for (String userAndRoomId : roomIds) {
 			String url = endpoint;
-			String roomId = userAndRoomId;
+			String roomId = userAndRoomId.trim();
 			String userId = "jenkins";
 			// Supported channel string formats:
 			// - user@channel
@@ -50,8 +50,8 @@ public class StandardMattermostService implements MattermostService {
 			// - @dmchannel
 			int atPos = userAndRoomId.indexOf("@");
 			if (atPos > 0 && atPos < userAndRoomId.length() - 1) {
-			    userId = userAndRoomId.substring(0, atPos);
-			    roomId = userAndRoomId.substring(atPos + 1);
+			    userId = userAndRoomId.substring(0, atPos).trim();
+			    roomId = userAndRoomId.substring(atPos + 1).trim();
 			}
         
 			String roomIdString = roomId;


### PR DESCRIPTION
Referring to issue #21 I changed the sources a little to allowing spaces within author names. The altered version is running like a charm in our corporate Jenkins.