### PR TITLE
Adds argument for additional "text" field of webhook payload

### DIFF
--- a/src/main/java/jenkins/plugins/mattermost/MattermostService.java
+++ b/src/main/java/jenkins/plugins/mattermost/MattermostService.java
@@ -4,4 +4,6 @@ public interface MattermostService {
 	boolean publish(String message);
 
 	boolean publish(String message, String color);
+
+	boolean publish(String message, String text, String color);
 }

--- a/src/main/java/jenkins/plugins/mattermost/StandardMattermostService.java
+++ b/src/main/java/jenkins/plugins/mattermost/StandardMattermostService.java
@@ -38,6 +38,10 @@ public class StandardMattermostService implements MattermostService {
 	}
 
 	public boolean publish(String message, String color) {
+		return publish(message, "", color);
+	}
+
+	public boolean publish(String message, String text, String color) {
 		boolean result = true;
 		for (String userAndRoomId : roomIds) {
 			String url = endpoint;
@@ -50,10 +54,10 @@ public class StandardMattermostService implements MattermostService {
 			// - @dmchannel
 			int atPos = userAndRoomId.indexOf("@");
 			if (atPos > 0 && atPos < userAndRoomId.length() - 1) {
-			    userId = userAndRoomId.substring(0, atPos).trim();
-			    roomId = userAndRoomId.substring(atPos + 1).trim();
+					userId = userAndRoomId.substring(0, atPos).trim();
+					roomId = userAndRoomId.substring(atPos + 1).trim();
 			}
-        
+
 			String roomIdString = roomId;
 
 			if (StringUtils.isEmpty(roomIdString)) {
@@ -83,6 +87,7 @@ public class StandardMattermostService implements MattermostService {
 				attachment.put("mrkdwn_in", mrkdwn);
 				JSONArray attachments = new JSONArray();
 				attachments.put(attachment);
+				json.put("text", text);
 				json.put("attachments", attachments);
 
 				if (!roomId.isEmpty()) json.put("channel", roomId);

--- a/src/main/java/jenkins/plugins/mattermost/workflow/MattermostSendStep.java
+++ b/src/main/java/jenkins/plugins/mattermost/workflow/MattermostSendStep.java
@@ -22,6 +22,7 @@ import javax.inject.Inject;
 public class MattermostSendStep extends AbstractStepImpl {
 
     private final @Nonnull String message;
+    private String text;
     private String color;
     private String channel;
     private String endpoint;
@@ -34,8 +35,17 @@ public class MattermostSendStep extends AbstractStepImpl {
         return message;
     }
 
+    public String getText() {
+        return text;
+    }
+
     public String getColor() {
         return color;
+    }
+
+    @DataBoundSetter
+    public void setText(String text) {
+        this.text = Util.fixEmpty(text);
     }
 
     @DataBoundSetter
@@ -128,14 +138,15 @@ public class MattermostSendStep extends AbstractStepImpl {
             MattermostNotifier.DescriptorImpl slackDesc = jenkins.getDescriptorByType(MattermostNotifier.DescriptorImpl.class);
             String team = step.endpoint != null ? step.endpoint : slackDesc.getEndpoint();
             String channel = step.channel != null ? step.channel : slackDesc.getRoom();
-            String icon = step.icon != null ? step.icon: slackDesc.getIcon();
+            String icon = step.icon != null ? step.icon : slackDesc.getIcon();
             String color = step.color != null ? step.color : "";
+            String text = step.text != null ? step.text : "";
 
             //placing in console log to simplify testing of retrieving values from global config or from step field; also used for tests
             listener.getLogger().printf("Mattermost Send Pipeline step configured values from global config - connector: %s, icon: %s, channel: %s, color: %s", step.endpoint == null, step.icon == null, step.channel == null, step.color == null);
 
             MattermostService slackService = getMattermostService(team, channel, icon);
-            boolean publishSuccess = slackService.publish(step.message, color);
+            boolean publishSuccess = slackService.publish(step.message, text, color);
             if (!publishSuccess && step.failOnError) {
                 throw new AbortException("Mattermost notification failed. See Jenkins logs for details.");
             } else if (!publishSuccess) {

--- a/src/main/resources/jenkins/plugins/mattermost/workflow/MattermostSendStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/mattermost/workflow/MattermostSendStep/config.jelly
@@ -4,6 +4,9 @@
     <f:entry field="message" title="Message">
         <f:textbox/>
     </f:entry>
+    <f:entry field="text" title="Text">
+        <f:textbox/>
+    </f:entry>
     <f:entry field="color" title="Color">
         <f:textbox/>
     </f:entry>

--- a/src/main/resources/jenkins/plugins/mattermost/workflow/MattermostSendStep/help-text.html
+++ b/src/main/resources/jenkins/plugins/mattermost/workflow/MattermostSendStep/help-text.html
@@ -1,0 +1,9 @@
+<div>
+    This text is the main message after the message attachment, and can contain standard message
+    markup.
+    The content may contain user "mentions" and highlights.<br>
+    <code>
+        mattermostSend prext: "@foo @bar" color: "#439FE0", message: "Build Started: ${env.JOB_NAME}
+        ${env.BUILD_NUMBER}"
+    </code>
+</div>

--- a/src/test/java/jenkins/plugins/mattermost/MattermostNotifierTest.java
+++ b/src/test/java/jenkins/plugins/mattermost/MattermostNotifierTest.java
@@ -67,6 +67,10 @@ public class MattermostNotifierTest extends TestCase {
 			return response;
 		}
 
+		public boolean publish(String message, String text, String color) {
+			return response;
+		}
+
 		public void setResponse(boolean response) {
 			this.response = response;
 		}

--- a/src/test/java/jenkins/plugins/mattermost/workflow/MattermostSendStepTest.java
+++ b/src/test/java/jenkins/plugins/mattermost/workflow/MattermostSendStepTest.java
@@ -74,7 +74,7 @@ public class MattermostSendStepTest {
 
         stepExecution.run();
         verify(stepExecution, times(1)).getMattermostService("endpoint", "channel", "icon");
-        verify(mattermostServiceMock, times(1)).publish("message", "good");
+        verify(mattermostServiceMock, times(1)).publish("message", "", "good");
         assertFalse(stepExecution.step.isFailOnError());
     }
 
@@ -98,12 +98,13 @@ public class MattermostSendStepTest {
         when(stepExecution.getMattermostService(anyString(), anyString(), anyString())).thenReturn(mattermostServiceMock);
 
         stepExecution.run();
-        verify(stepExecution, times(1)).getMattermostService("globalEndpoint","globalChannel", "globalIcon");
-        verify(mattermostServiceMock, times(1)).publish("message", "");
+        verify(stepExecution, times(1)).getMattermostService("globalEndpoint", "globalChannel", "globalIcon");
+        verify(mattermostServiceMock, times(1)).publish("message", "", "");
         assertNull(stepExecution.step.getEndpoint());
         assertNull(stepExecution.step.getIcon());
         assertNull(stepExecution.step.getChannel());
         assertNull(stepExecution.step.getColor());
+        assertNull(stepExecution.step.getText());
     }
 
     @Test
@@ -124,8 +125,29 @@ public class MattermostSendStepTest {
         when(stepExecution.getMattermostService(anyString(), anyString(), anyString())).thenReturn(mattermostServiceMock);
 
         stepExecution.run();
-        verify(mattermostServiceMock, times(1)).publish("message", "");
+        verify(mattermostServiceMock, times(1)).publish("message", "", "");
         assertNull(stepExecution.step.getColor());
+    }
+    
+    @Test
+    public void testNonNullPretext() throws Exception {
+
+        MattermostSendStep.SlackSendStepExecution stepExecution = spy(new MattermostSendStep.SlackSendStepExecution());
+        MattermostSendStep mattermostSendStep = new MattermostSendStep("message");
+        mattermostSendStep.setText("@foo @bar");
+        stepExecution.step = mattermostSendStep;
+
+        when(Jenkins.getInstance()).thenReturn(jenkins);
+
+        stepExecution.listener = taskListenerMock;
+
+        when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
+        doNothing().when(printStreamMock).println();
+
+        when(stepExecution.getMattermostService(anyString(), anyString(), anyString())).thenReturn(mattermostServiceMock);
+
+        stepExecution.run();
+        verify(mattermostServiceMock, times(1)).publish("message", "@foo @bar", "");
     }
 
     @Test


### PR DESCRIPTION
In response to: https://github.com/jovandeginste/jenkins-mattermost-plugin/issues/5

Since it looks like `attachments` will not become highlighted or searchable [in the meantime](https://github.com/mattermost/mattermost-server/issues/6029), I made this change.

This adds an optional `text` argument to `mattermostSend` that allows users to include formattable text. This can be used in `Jenkinsfile` for example.