### PR TITLE
add custom proxy settings

### DIFF
--- a/src/main/java/jenkins/plugins/mattermost/MattermostNotifier.java
+++ b/src/main/java/jenkins/plugins/mattermost/MattermostNotifier.java
@@ -44,6 +44,11 @@ public class MattermostNotifier extends Notifier {
   private String room;
   private String icon;
   private String sendAs;
+  private boolean useCustomProxy;
+  private Secret proxyPassword;
+  private String proxyUsername;
+  private String proxyServer;
+  private int proxyPort;
   private boolean startNotification;
   private boolean notifySuccess;
   private boolean notifyAborted;
@@ -86,6 +91,24 @@ public class MattermostNotifier extends Notifier {
     } else {
       return buildServerUrl;
     }
+  }
+
+  public boolean isUseCustomProxy() { return useCustomProxy; }
+
+  public Secret getProxyPassword() {
+    return proxyPassword;
+  }
+
+  public String getProxyUsername() {
+    return proxyUsername;
+  }
+
+  public String getProxyServer() {
+    return proxyServer;
+  }
+
+  public int getProxyPort() {
+    return proxyPort;
   }
 
   public String getSendAs() {
@@ -150,6 +173,28 @@ public class MattermostNotifier extends Notifier {
 
   public void setEndpoint(String endpoint) {
     this.endpoint = Secret.fromString(endpoint);
+  }
+
+  public void setProxyPassword(String proxyPassword) {
+    this.proxyPassword = Secret.fromString(proxyPassword);
+  }
+
+  @DataBoundSetter
+  public void setUseCustomProxy(boolean useCustomProxy) { this.useCustomProxy = useCustomProxy; }
+
+  @DataBoundSetter
+  public void setProxyUsername(String proxyUsername) {
+    this.proxyUsername = proxyUsername;
+  }
+
+  @DataBoundSetter
+  public void setProxyServer(String proxyServer) {
+    this.proxyServer = proxyServer;
+  }
+
+  @DataBoundSetter
+  public void setProxyPort(int proxyPort) {
+    this.proxyPort = proxyPort;
   }
 
   @DataBoundSetter
@@ -270,6 +315,8 @@ public class MattermostNotifier extends Notifier {
 //    ,includeCustomAttachmentMessage,customAttachmentMessage,includeCustomMessage,customMessage);
 //  }
 
+
+
   @DataBoundConstructor
   public MattermostNotifier(
           final String endpoint,
@@ -385,9 +432,66 @@ public class MattermostNotifier extends Notifier {
     private String buildServerUrl;
     private String sendAs;
 
+    private boolean useCustomProxy;
+    private String proxyServer;
+    private int proxyPort;
+    private String proxyUsername;
+    private Secret proxyPassword;
+
     public DescriptorImpl() {
       load();
     }
+
+    public boolean isUseCustomProxy() { return useCustomProxy; }
+
+    public String getProxyServer(){
+      return proxyServer;
+    }
+
+    public int getProxyPort(){
+      return proxyPort;
+    }
+
+    public String getProxyUsername(){
+      return proxyUsername;
+    }
+
+    public Secret getProxyPassword(){
+      return proxyPassword;
+    }
+
+    @DataBoundSetter
+    public void setUseCustomProxy(boolean useCustomProxy) { this.useCustomProxy = useCustomProxy; }
+
+    @DataBoundSetter
+    public void setProxyServer(String proxyServer) {
+      this.proxyServer = proxyServer;
+    }
+
+    @DataBoundSetter
+    public void setProxyPort(int proxyPort) {
+      this.proxyPort = proxyPort;
+    }
+
+    @DataBoundSetter
+    public void setProxyUsername(String proxyUsername) {
+      this.proxyUsername = proxyUsername;
+    }
+
+    @DataBoundSetter
+    public void setProxyPassword(Secret proxyPassword) {
+      this.proxyPassword = proxyPassword;
+    }
+
+    @DataBoundSetter
+    public void setProxyPassword(String proxyPassword) {
+      if(proxyPassword == null){
+        this.proxyPassword = null;
+        return;
+      }
+      this.setProxyPassword(Secret.fromString(proxyPassword));
+    }
+
 
     @DataBoundSetter
     public void setEndpoint(String endpoint) {
@@ -474,13 +578,14 @@ public class MattermostNotifier extends Notifier {
       return "Mattermost Notifications";
     }
 
+
     @POST
     public FormValidation doTestConnection(
         @QueryParameter("endpoint") final String endpoint,
         @QueryParameter("room") final String room,
         @QueryParameter("icon") final String icon,
         @QueryParameter("buildServerUrl") final String buildServerUrl)
-        throws FormException {
+            throws FormException {
       if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER))
       {
         return FormValidation.error("Insufficient permission.");

--- a/src/main/resources/jenkins/plugins/mattermost/MattermostNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/mattermost/MattermostNotifier/global.jelly
@@ -26,6 +26,28 @@
     <f:entry title="Build Server URL" help="/plugin/mattermost/help-globalConfig-mattermostBuildServerUrl.html">
         <f:textbox  field="buildServerUrl"/>
     </f:entry>
+
+<!--    <f:optionalBlock title="Custom proxy settings"  >-->
+    <f:advanced title="Mattermost Custom Proxy Settings">
+        <f:entry title="${%Use Custom Proxy}" help="Enables using custom proxy">
+            <f:checkbox field="useCustomProxy"/>
+        </f:entry>
+        <f:entry title="${%Proxy Server}" help="Enter proxy address">
+            <f:textbox field="proxyServer" />
+        </f:entry>
+        <f:entry title="${%Proxy Port}" help="Enter proxy port">
+            <f:number field="proxyPort" />
+        </f:entry>
+        <f:entry title="${%Proxy UserName}" help="Enter proxy username">
+            <f:textbox field="proxyUsername" />
+        </f:entry>
+        <f:entry title="${%Proxy Password}" help="Enter proxy password">
+            <f:password field="proxyPassword" />
+        </f:entry>
+    </f:advanced>
+<!--      </f:optionalBlock>-->
+
+
     <f:validateButton
         title="${%Test Connection}" progress="${%Testing...}"
         method="testConnection" with="endpoint,room,buildServerUrl"


### PR DESCRIPTION
Adds a custom proxy settings in configuration.
If checked, custom proxy values are used to access Mattermost endpoint.
Otherwise global Jenkins proxy is used (if set).

Closes #34 

Since this is my first attempt to a Jenkins so probably there might be a lot more to do.
First of all I was little confused with the `@DataBoundSetter` anotations - not sure if i've used them corectly.

Second thing: i was wondering how to access the settings from within the publish method, I've end up with static method
```java
private static MattermostNotifier.DescriptorImpl getServiceDescriptor()
```
that might not be the best solution.

Also I tried using `<f:optionalBlock>` instead of `<f:advanced>` in the `Settings`, but I failed.
I may attempt to this one more time if you find current solution not sufficient. 

